### PR TITLE
[46기 김민지] Footer UI 구현

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,7 +1,82 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMap, faListUl } from '@fortawesome/free-solid-svg-icons';
+import FooterDataModal from '../Modal/FooterDataModal';
+import { ETC, RIGHT_ETC } from '../uiData/footerConstData';
+import * as S from './StyleFooter';
 
 const Footer = () => {
-  return <div>Footer</div>;
+  const [isMap, setIsMap] = useState(false);
+  const [isOpenModal, setIsOpenModal] = useState(false);
+
+  const handleModal = () => {
+    setIsOpenModal(prev => !prev);
+  };
+  return (
+    <S.StyleFooter>
+      <S.MapBtn onClick={() => setIsMap(!isMap)}>
+        {isMap ? (
+          <S.MapBtnLink to={`/main/?map_open=${isMap}`}>
+            <S.MapBtnSpan>목록 보기</S.MapBtnSpan>
+            <FontAwesomeIcon icon={faListUl} />
+          </S.MapBtnLink>
+        ) : (
+          <S.MapBtnLink to={`/main/?map_open=${isMap}`}>
+            <S.MapBtnSpan>지도 표시하기</S.MapBtnSpan>
+            <FontAwesomeIcon icon={faMap} />
+          </S.MapBtnLink>
+        )}
+      </S.MapBtn>
+      <S.FooterContainer isMap={isMap}>
+        <S.FooterInner>
+          <S.FooterWrapper>
+            <S.FooterWrapperDiv>
+              © 2023 Space Around, Inc
+              <S.Ul>
+                {ETC.map(etc => {
+                  return (
+                    <S.Li key={etc.id}>
+                      <S.FooterLink to="/">{etc.value}</S.FooterLink>
+                    </S.Li>
+                  );
+                })}
+              </S.Ul>
+            </S.FooterWrapperDiv>
+            {RIGHT_ETC.map(rightEtc =>
+              rightEtc.id !== '3' ? (
+                <S.SlideDiv key={rightEtc.id}>
+                  <span>{rightEtc.icon}</span>
+                  {rightEtc.value}
+                </S.SlideDiv>
+              ) : (
+                <S.SlideDiv key={rightEtc.id}>
+                  {rightEtc.value}
+                  <span onClick={handleModal}>{rightEtc.icon}</span>
+                </S.SlideDiv>
+              )
+            )}
+          </S.FooterWrapper>
+        </S.FooterInner>
+        <S.FooterDiv>
+          웹사이트 제공자: Space Around, private unlimited company, Starting
+          from 15 June 2023 | 팀 : MinJi, Kaylla, Jae Woong, Tim Oh | VAT 번호:
+          IE9827384L | 사업자 등록 번호: IE 511825 | 연락처:
+          spaces@spacearound.com, 웹사이트, 080-123-1235 | 호스팅 서비스
+          제공업체: 스페이스 어라운드 웹서비스 | 스페이스 어라운드는 통신판매
+          중개자로 스페이스 어라운드 플랫폼을 통하여 게스트와 호스트 사이에
+          이루어지는 통신판매의 당사자가 아닙니다. 스페이스 어라운드 플랫폼을
+          통하여 예약된 숙소, 체험, 호스트 서비스에 관한 의무와 책임은 해당
+          서비스를 제공하는 호스트에게 있습니다.
+        </S.FooterDiv>
+        {isOpenModal && (
+          <FooterDataModal
+            isOpenModal={isOpenModal}
+            setIsOpenModal={setIsOpenModal}
+          />
+        )}
+      </S.FooterContainer>
+    </S.StyleFooter>
+  );
 };
 
 export default Footer;

--- a/src/components/Footer/FooterData.js
+++ b/src/components/Footer/FooterData.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import * as S from './StyleFooterData';
+import { INFO_CATEGORY } from '../uiData/footerConstData';
+
+const FooterData = ({ isOpenModal, setIsOpenModal }) => {
+  return (
+    <div>
+      <S.StyleFooterDataInner>
+        <div>
+          <FontAwesomeIcon
+            icon={faXmark}
+            onClick={() => {
+              setIsOpenModal(prev => !prev);
+            }}
+          />
+        </div>
+        <S.StyleFooterDataWrapper>
+          {INFO_CATEGORY.map(category => {
+            return (
+              <ul key={category.infoId}>
+                <S.FooterDataH2>{category.infoValue}</S.FooterDataH2>
+                {category.subInfo.map(sub => {
+                  return (
+                    <S.FooterDataLi
+                      className="bottomMenuCategoryLi"
+                      key={sub.subInfoId}
+                    >
+                      <S.FooterDataLink to="/">
+                        {sub.subInfoValue}
+                      </S.FooterDataLink>
+                    </S.FooterDataLi>
+                  );
+                })}
+              </ul>
+            );
+          })}
+        </S.StyleFooterDataWrapper>
+      </S.StyleFooterDataInner>
+    </div>
+  );
+};
+
+export default FooterData;

--- a/src/components/Footer/ShowEffect.js
+++ b/src/components/Footer/ShowEffect.js
@@ -1,0 +1,24 @@
+import { keyframes } from 'styled-components';
+
+export const moveUp = keyframes`
+from {
+    opacity: 1;
+    margin-bottom: 0;
+
+  }
+  to {
+    opacity: 0;
+    margin-bottom: -50px;
+  }
+`;
+
+export const moveDown = keyframes`
+from {
+    opacity: 0;
+    margin-top: -50px;
+  }
+  to {
+    opacity: 1;
+    margin-bottom: 0;
+  }
+`;

--- a/src/components/Footer/StyleFooter.js
+++ b/src/components/Footer/StyleFooter.js
@@ -1,0 +1,118 @@
+import styled, { css } from 'styled-components';
+import { Link } from 'react-router-dom';
+
+export const MapBtn = styled.button`
+  position: absolute;
+  top: -100%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 140px;
+  height: 50px;
+  color: white;
+  background-color: #232323;
+  border-radius: 25px;
+  border: none;
+`;
+
+export const MapBtnSpan = styled.span`
+  margin-right: 10px;
+`;
+
+export const MapBtnLink = styled(Link)`
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+`;
+
+export const StyleFooter = styled.div`
+  background-color: white;
+  z-index: 1;
+  position: fixed;
+  width: 100%;
+  bottom: 0px;
+
+  padding: 0px 20px;
+`;
+
+export const FooterContainer = styled.div`
+  ${props =>
+    props.isMap
+      ? css`
+          visibility: hidden;
+        `
+      : css`
+          visibility: visible;
+        `}
+  border-top: 1px solid #ebebeb;
+`;
+
+export const FooterInner = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  height: auto;
+  padding: 20px 20px;
+`;
+
+export const FooterWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  flex: 1;
+`;
+
+export const FooterWrapperDiv = styled.div`
+  display: flex;
+  margin-right: auto;
+  flex-grow: 1;
+  font-weight: 350;
+  font-size: 14px;
+  margin-right: 10px;
+`;
+
+export const Ul = styled.ul`
+  margin-left: 5px;
+  list-style: none;
+`;
+
+export const Li = styled.li`
+  float: left;
+  font-weight: 350;
+  font-size: 14px;
+  margin-right: 10px;
+  color: #464646;
+`;
+
+export const FooterLink = styled(Link)`
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+  &:after {
+    width: 90%;
+    display: block;
+    content: '';
+    border-bottom: solid 1px black;
+    transform: scaleX(0) translateX(10%);
+    transition: transform 250ms ease-in-out;
+  }
+  &:hover:after {
+    transform: scaleX(1) translateX(10%);
+  }
+`;
+
+export const SlideDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-weight: 350;
+  font-size: 15px;
+  margin-right: 10px;
+`;
+
+export const FooterDiv = styled.div`
+  border-top: 1px solid #dddddd;
+  padding-top: 6px;
+  font-weight: 350;
+  font-size: 10px;
+  color: #929292;
+`;

--- a/src/components/Footer/StyleFooterData.js
+++ b/src/components/Footer/StyleFooterData.js
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const StyleFooterDataInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 30px;
+`;
+
+export const StyleFooterDataWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  padding: 30px;
+`;
+
+export const FooterDataLi = styled.li`
+  margin-bottom: 25px;
+  color: #737373;
+  font-size: 14px;
+`;
+export const FooterDataH2 = styled.h2`
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 20px;
+`;
+export const FooterDataLink = styled(Link)`
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+  display: inline-block;
+  position: relative;
+  &:after {
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 100%;
+    height: 1px;
+    content: '';
+    background-color: #737373;
+    transform: scaleX(0);
+    transition: transform 250ms ease-in-out;
+  }
+  &:hover:after {
+    transform: scaleX(1);
+  }
+`;

--- a/src/components/Modal/FooterDataModal.js
+++ b/src/components/Modal/FooterDataModal.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import FooterData from '../Footer/FooterData';
+import { moveUp, moveDown } from '../Footer/ShowEffect';
+import { StyleFooterDataModal, ModalBox } from './StyleFooterDataModal';
+
+const FooterDataModal = ({ isOpenModal, setIsOpenModal }) => {
+  return (
+    <StyleFooterDataModal
+      onClick={() => {
+        setIsOpenModal(prev => !prev);
+      }}
+    >
+      <ModalBox
+        isOpenModal={isOpenModal}
+        moveUp={moveUp}
+        moveDown={moveDown}
+        onClick={e => e.stopPropagation()}
+      >
+        {isOpenModal && (
+          <FooterData
+            isOpenModal={isOpenModal}
+            setIsOpenModal={setIsOpenModal}
+          />
+        )}
+      </ModalBox>
+    </StyleFooterDataModal>
+  );
+};
+
+export default FooterDataModal;

--- a/src/components/Modal/StyleFooterDataModal.js
+++ b/src/components/Modal/StyleFooterDataModal.js
@@ -1,0 +1,32 @@
+import styled, { css } from 'styled-components';
+import { moveUp, moveDown } from '../Footer/ShowEffect';
+
+export const StyleFooterDataModal = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalBox = styled.div`
+  ${props =>
+    props.isOpenModal
+      ? css`
+          animation: ${moveDown} 0.3s;
+        `
+      : css`
+          animation: ${moveUp} 0.3s;
+        `}
+
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 300px;
+  border: none;
+  border-radius: 30px 30px 0px 0px;
+  background-color: white;
+`;

--- a/src/components/uiData/footerConstData.js
+++ b/src/components/uiData/footerConstData.js
@@ -1,0 +1,83 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faGlobe, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+export const ETC = [
+  {
+    id: '1',
+    value: '· 개인정보 처리방침',
+  },
+  {
+    id: '2',
+    value: '· 이용약관',
+  },
+  {
+    id: '3',
+    value: '· 사이트맵',
+  },
+  {
+    id: '4',
+    value: '· 한국의 변경된 환불 정책',
+  },
+  {
+    id: '5',
+    value: '· 회사 세부정보',
+  },
+];
+
+export const INFO_CATEGORY = [
+  {
+    infoId: '1',
+    infoValue: '스페이스어라운드 지원',
+    subInfo: [
+      { subInfoId: 10, subInfoValue: '도움말 센터' },
+      { subInfoId: 11, subInfoValue: '장애인 지원' },
+      { subInfoId: 12, subInfoValue: '예약 취소 옵션' },
+      { subInfoId: 13, subInfoValue: '이웃 민원 신고' },
+    ],
+  },
+  {
+    infoId: '2',
+    infoValue: '커뮤니티',
+    subInfo: [
+      { subInfoId: 20, subInfoValue: '재난 구호 숙소' },
+      { subInfoId: 21, subInfoValue: '차별 철폐를 위한 노력' },
+    ],
+  },
+  {
+    infoId: '3',
+    infoValue: '호스팅',
+    subInfo: [
+      { subInfoId: 30, subInfoValue: '당신을 공간을 공유하세요' },
+      { subInfoId: 31, subInfoValue: '호스트를 위한 에어커버' },
+      { subInfoId: 32, subInfoValue: '호스팅 자료 둘러보기' },
+      { subInfoId: 33, subInfoValue: '책임감 있는 호스팅' },
+    ],
+  },
+  {
+    infoId: '4',
+    infoValue: '스페이스어라운드',
+    subInfo: [
+      { subInfoId: 40, subInfoValue: '뉴스룸' },
+      { subInfoId: 41, subInfoValue: '새로운 기능에 대해 알아보기' },
+      { subInfoId: 42, subInfoValue: '채용정보' },
+      { subInfoId: 43, subInfoValue: '투자자 정보' },
+    ],
+  },
+];
+
+export const RIGHT_ETC = [
+  {
+    id: '1',
+    value: ' 한국어(KR)',
+    icon: <FontAwesomeIcon icon={faGlobe} />,
+  },
+  {
+    id: '2',
+    value: '₩ KRW',
+    icon: null,
+  },
+  {
+    id: '3',
+    value: '지원 및 참고 자료 ',
+    icon: <FontAwesomeIcon icon={faChevronUp} />,
+  },
+];


### PR DESCRIPTION
<img width="1502" alt="스크린샷 2023-06-20 오전 2 13 00" src="https://github.com/wecode-bootcamp-korea/46-2nd-B1A4-frontend/assets/68523994/ad24c1f7-3167-4003-8923-732b6d8c1239">
<img width="1500" alt="스크린샷 2023-06-20 오전 2 13 08" src="https://github.com/wecode-bootcamp-korea/46-2nd-B1A4-frontend/assets/68523994/d6ad78b3-7d0c-4c1e-bdb8-ce3b3b0db7bd">

![스크린샷 2023-06-20 오후 2 35 45](https://github.com/wecode-bootcamp-korea/46-2nd-B1A4-frontend/assets/68523994/81ed4b8d-e893-4687-8eac-66ddb893f889)


##### Footer 구현 기능
- Footer UI
- Footer Data Modal 구현
- 목록 보기 / 지도보기 버튼 구현 및 param 추가

##### 성장 포인트
- position을 활용하여 구조를 잡을 수 있었습니다 
- Footer에 모달을 추가하여 중첩된 화면을 구현할 수 있게되었습니다.
- 버튼을 클릭할 때마다 useParams의 값을 달리 주어 화면전환을 할 수 있었습니다.
