### PR TITLE
[46기 손자현] 메인페이지 지도뷰 레이아웃과 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "46-2nd-b1a4-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@emotion/react": "^11.11.1",
-        "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.3",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
@@ -81,6 +79,22 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apideck/better-ajv-errors": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
+      "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
+      "dependencies": {
+        "json-schema": "^0.4.0",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2494,9 +2508,9 @@
       }
     },
     "node_modules/@emotion/hash": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
@@ -2582,24 +2596,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3480,10 +3476,11 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
       "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
       "dependencies": {
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
       },
       "engines": {
@@ -5054,6 +5051,11 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -7450,9 +7452,9 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7779,6 +7781,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dom-helpers/node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -9110,11 +9117,6 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -10359,6 +10361,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -11098,6 +11108,11 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/jest-docblock": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
@@ -11597,6 +11612,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/jest-mock": {
       "version": "27.5.1",
@@ -17474,11 +17494,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
-    },
     "node_modules/sucrase": {
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.32.0.tgz",
@@ -19012,22 +19027,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@apideck/better-ajv-errors": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.6.tgz",
-      "integrity": "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==",
-      "dependencies": {
-        "json-schema": "^0.4.0",
-        "jsonpointer": "^5.0.0",
-        "leven": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "ajv": ">=8"
       }
     },
     "node_modules/workbox-build/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.3",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,17 @@
 <html lang="ko">
   <head>
     <meta charset="utf-8" />
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=fde98289a42404a2aef1b9d89dc11a3b"></script>
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link href=“https://fonts.cdnfonts.com/css/circular-std” rel=“stylesheet”>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=4483fe229d9fdd359262c2f5f0845956"
+    ></script>
     <script
       type="text/javascript"
       src="https://static.nid.naver.com/js/naveridlogin_js_sdk_2.0.0.js"
       charset="utf-8"
     ></script>
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link href=“https://fonts.cdnfonts.com/css/circular-std” rel=“stylesheet”>
     <title>Space Around</title>
   </head>
   <body>

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,14 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { useSearchParams } from 'react-router-dom';
 import StudioCard from '../../components/StudioCard/StudioCard';
-import { Container, MainBackground } from './StyleMain';
+import MainMap from './MainMap';
+import { MainBackground, Container } from './StyleMain';
 
 const Main = () => {
   const [mockData, setMockData] = useState([]);
   const [filterData, setFilterData] = useState([]);
   const [offset, setOffset] = useState(0);
   const [ref, inView] = useInView();
-
+  const [studioCardData, setStudioCardData] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [isMapOpen, setIsMapOpen] = useState(false);
   const settings = {
     dots: true,
     infinite: true,
@@ -21,14 +25,6 @@ const Main = () => {
   const nextOffset = LIMIT + offset;
 
   // 추후 mockData 통신
-  // useEffect(() => {
-  //   fetch(`/data/main.json`)
-  //     .then(res => res.json())
-  //     .then(data => {
-  //       setMockData(data.data);
-  //     });
-  // }, []);
-
   useEffect(() => {
     fetch(
       `${
@@ -39,12 +35,30 @@ const Main = () => {
     )
       .then(res => res.json())
       .then(data => {
-        setFilterData(prev => prev.concat(data.data));
-        setOffset(prev => prev + LIMIT);
+        setMockData(data.data);
       });
-  }, [inView]);
+  }, []);
 
-  if (filterData.length === 0) return null;
+  // useEffect(() => {
+  //   fetch(
+  //     `http://10.58.52.71:8001/studios/filter?studioCategoryId=1&offset=${
+  //       nextOffset - 9
+  //     }&limit=${LIMIT}`
+  //   )
+  //     .then(res => res.json())
+  //     .then(data => {
+  //       setFilterData(prev => prev.concat(data.data));
+  //       setOffset(prev => prev + LIMIT);
+  //     });
+  // }, [inView]);
+
+  const params = searchParams.get('map_open');
+
+  useEffect(() => {
+    setIsMapOpen(params === 'true');
+  }, [params]);
+
+  // if (!studioCardData.length) return null;
 
   // 추후 mockData 통신
   // if (mockData.length === 0) return null;
@@ -60,15 +74,24 @@ const Main = () => {
             );
           })}
       </Container> */}
+
       <MainBackground>
-        <Container>
-          {filterData.map(list => {
-            return (
-              <StudioCard key={list.studioId} list={list} settings={settings} />
-            );
-          })}
-          <div ref={ref}></div>
-        </Container>
+        {isMapOpen ? (
+          <MainMap />
+        ) : (
+          <Container>
+            {filterData.map(list => {
+              return (
+                <StudioCard
+                  key={list.studioId}
+                  list={list}
+                  settings={settings}
+                />
+              );
+            })}
+            <div ref={ref}></div>
+          </Container>
+        )}
       </MainBackground>
     </>
   );

--- a/src/pages/Main/MainMap.js
+++ b/src/pages/Main/MainMap.js
@@ -1,0 +1,158 @@
+import React, { useEffect, useRef } from 'react';
+import { MapContainer, Map } from './StyleMainMap';
+import { useNavigate } from 'react-router-dom';
+const { kakao } = window;
+
+const MainMap = () => {
+  const mapRef = useRef();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const container = document.getElementById('map');
+    const options = {
+      center: new kakao.maps.LatLng(36.3437387096971, 127.41027496730207),
+      level: 12,
+    };
+
+    mapRef.current = new kakao.maps.Map(container, options);
+
+    const overlayInfos = productInfos?.map(info => {
+      return {
+        title: info.title,
+        lat: info.lat,
+        lng: info.lng,
+        img: info.img[0],
+        price: info.price,
+        region: info.region,
+      };
+    });
+
+    const imageSrc =
+      'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
+
+    overlayInfos.forEach(el => {
+      const imageSize = new kakao.maps.Size(24, 35);
+      const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
+      let positions = new kakao.maps.LatLng(el.lat, el.lng);
+
+      let marker = new kakao.maps.Marker({
+        map: mapRef.current,
+        position: positions,
+        image: markerImage,
+      });
+
+      let content = document.createElement('div');
+      content.classList.add('overlayWrap');
+
+      const studioImg = document.createElement('img');
+      studioImg.classList.add('overlayImg');
+      studioImg.src = el.img;
+      content.appendChild(studioImg);
+      studioImg.onclick = function () {
+        navigate('/detail/1');
+      };
+
+      const textContainer = document.createElement('div');
+      textContainer.classList.add('textContainer');
+      content.appendChild(textContainer);
+
+      const accommWrap = document.createElement('div');
+      accommWrap.classList.add('accommInfoWrap');
+      textContainer.appendChild(accommWrap);
+      accommWrap.onclick = function () {
+        navigate('/detail/1');
+      };
+
+      const studioName = document.createElement('h1');
+      studioName.appendChild(document.createTextNode(`${el.title}`));
+      studioName.classList.add('accommName');
+      accommWrap.appendChild(studioName);
+
+      const studioRegion = document.createElement('p');
+      studioRegion.appendChild(document.createTextNode(`${el.region}`));
+      studioRegion.classList.add('accommRegion');
+      accommWrap.appendChild(studioRegion);
+
+      const btnContainer = document.createElement('div');
+      btnContainer.classList.add('btnContainer');
+      textContainer.appendChild(btnContainer);
+
+      const closeBtn = document.createElement('button');
+      closeBtn.classList.add('closeBtn');
+      closeBtn.appendChild(document.createTextNode('×'));
+      closeBtn.onclick = function () {
+        customOverlay.setMap(null);
+      };
+      btnContainer.appendChild(closeBtn);
+
+      const price = el.price.toLocaleString();
+      const contentPrice = document.createElement('div');
+      contentPrice.classList.add('overlayPrice');
+      contentPrice.appendChild(document.createTextNode(`₩${price}`));
+      contentPrice.onclick = () => {
+        customOverlay.setMap(mapRef.current);
+      };
+
+      const customOverlay = new kakao.maps.CustomOverlay({
+        position: positions,
+        content: content,
+        xAnchor: 0.46,
+        yAnchor: 1.22,
+      });
+
+      const customOverlayPrice = new kakao.maps.CustomOverlay({
+        position: positions,
+        content: contentPrice,
+        yAnchor: 1.5,
+      });
+      customOverlayPrice.setMap(mapRef.current);
+
+      kakao.maps.event.addListener(marker, 'click', function () {
+        customOverlay.setMap(mapRef.current);
+      });
+    });
+  }, []);
+
+  return (
+    <MapContainer>
+      <Map id="map"></Map>
+    </MapContainer>
+  );
+};
+
+export default MainMap;
+
+const productInfos = [
+  {
+    title: '팀 스튜디오',
+    lat: 37.62197524055062,
+    lng: 127.16017523675508,
+    img: ['/images/room6.jpg'],
+    price: '30000',
+    region: '역삼동',
+  },
+  {
+    title: '민지 스튜디오',
+    lat: 37.22197524055062,
+    lng: 127.0383774403176,
+    img: ['/images/room5.jpg'],
+    price: '40000',
+    region: '삼성동',
+  },
+  {
+    title: '자현 스튜디오',
+    lat: 36.48232513883755,
+    lng: 127.35824367516048,
+    img: ['/images/room7.jpg'],
+    price: '20000',
+    region: '대치동',
+  },
+  {
+    title: '재웅 스튜디오',
+    lat: 36.78656273069659,
+    lng: 126.45211256646381,
+    img: ['/images/room9.jpg'],
+    price: '15000',
+    region: '연희동',
+  },
+];

--- a/src/pages/Main/StyleMainMap.js
+++ b/src/pages/Main/StyleMainMap.js
@@ -1,0 +1,74 @@
+import styled, { css } from 'styled-components';
+
+export const MapContainer = styled.div`
+  width: 100vw;
+  height: calc(100vh - 100px);
+`;
+
+export const Map = styled.div`
+  width: 100%;
+  height: 100%;
+
+  .overlayWrap {
+    background-color: white;
+    border-radius: 10px;
+    width: 180px;
+    ${props => props.theme.flexBox('column', 'center', 'flex-start')}
+
+    .overlayImg {
+      width: 180px;
+      border-top-right-radius: 10px;
+      border-top-left-radius: 10px;
+    }
+    .textContainer {
+      ${props => props.theme.flexBox('row', 'space-between', 'flex-start')}
+      width: 100%;
+      padding: 3px;
+
+      .btnContainer {
+        width: 10%;
+        padding: 0 5px;
+        /* background-color: pink; */
+        ${props => props.theme.flexBox('row', 'flex-end', 'flex-end')}
+
+        .closeBtn {
+          background-color: white;
+          width: 1.4rem;
+          height: 1.4rem;
+          font-size: 1.4rem;
+          border: none;
+          border-radius: 10px;
+        }
+      }
+      .accommInfoWrap {
+        width: 90%;
+        padding: 4px 4px 6px 8px;
+
+        .accommName,
+        .accommRegion {
+          padding: 3px;
+        }
+
+        .accommName {
+          font-size: 0.95rem;
+          font-weight: 600;
+        }
+
+        .accommRegion {
+          font-size: 0.85rem;
+        }
+      }
+    }
+  }
+  .hidden {
+    display: none;
+    overflow: hidden;
+  }
+  .overlayPrice {
+    background-color: ${props => props.theme.primaryColor};
+    padding: 8px;
+    border-radius: 20px;
+    color: white;
+    text-shadow: 0.5px 0.5px 0.5px black;
+  }
+`;


### PR DESCRIPTION

##### 1. 이 브랜치에서 어떤걸 개발했는지 title,그리고 detail을 적어주세요.

##### 메인 페이지 지도뷰 레이아웃과 기능 구현
- 화면 하단에 목록보기/지도보기 버튼 누를시 리스트뷰 <-> 지도뷰 토글
- 카카오맵 API 불러오기
- 데이터로 받아온 경도위도로 지도에 마커띄우기
- 각 마커에 가격 커스텀오버레이와 디테일 커스텀오버레이(onclick) 띄우기
- 엑스버튼 누를시 오버레이 닫기 
- 디테일 오버레이의 사진이나 타이틀 누를시 디테일 페이지로 이동 
<br />

##### 2. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)

![Screen Shot 2023-06-26 at 12 18 13 AM](https://github.com/wecode-bootcamp-korea/46-2nd-B1A4-frontend/assets/123920778/beaf0503-f43a-44b2-a47d-b1027aebab5d)

<br />

##### 3. 이 브랜치에서 개발하면서 느꼇던 성장포인트를 적어주세요.

- 카카오맵에서 마커 커스터마이즈가 불가해서 (가격을 띄우고싶었다) 노란 마커(primary color)로 바꾸고 노란색 커스텀 오버레이를 띄워서 마커의 일부분처럼 만들었다.
- 처음엔 공식문서에 있던대로 content안에 html형식으로 넣었었는데 onclick 이벤트(닫기 기능)가 먹히지 않아서 여러방식을 시도해보다가 createElement로 하나씩 넣어주었다. 유지보수는 더 좋아진다고 하는데 코드가 다섯배이상 길어졌다... 
- 열려있는 디테일 오버레이를 닫기버튼으로 직접 닫는게 아니라 다른 오버레이 클릭해서 오픈할시 이미 열려있던 오버레이가 닫히는 로직을 짜보고싶었는데 아직 구현하지 못했다... 추후 더 시도해볼 예정
  <br />
